### PR TITLE
Return pack in response when registering a pack

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,9 +18,9 @@ package main
 
 import (
 	"fmt"
+	"github.com/HotelsDotCom/go-logger"
 	"math"
 	"os"
-	"github.com/HotelsDotCom/go-logger"
 	"strconv"
 )
 
@@ -40,14 +40,14 @@ const (
 )
 
 type Config struct {
-	MongoHost      string
-	Port           string
-	TLSCertPath    string
-	TLSKeyPath     string
-	AuthPolicyPath string
+	MongoHost          string
+	Port               string
+	TLSCertPath        string
+	TLSKeyPath         string
+	AuthPolicyPath     string
 	OidcIssuerURL      string
 	OidcIssuerClientID string
-	FlyteTTL       int
+	FlyteTTL           int
 }
 
 func NewConfig() Config {

--- a/config_test.go
+++ b/config_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"github.com/HotelsDotCom/go-logger/loggertest"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -38,7 +38,7 @@ func newflyteEnvVars() envVars {
 		authPolicyPathEnvName:  "/path/to/authpolicy",
 		oidcIssuerURLName:      "dex:5559",
 		oidcIssuerClientIDName: "example-app",
-		flyteTTLEnvName:       "86400",
+		flyteTTLEnvName:        "86400",
 	}
 }
 
@@ -142,7 +142,7 @@ func TestConfigShouldSetDefaultTTLAndLogOnStringToIntConversionError(t *testing.
 	// default flyte data ttl
 	assert.Equal(t, 31557600, c.FlyteTTL)
 	logMessages := loggertest.GetLogMessages()
-	assert.Equal(t, "Error converting FLYTE_TTL_IN_SECONDS to int, using default. " +
+	assert.Equal(t, "Error converting FLYTE_TTL_IN_SECONDS to int, using default. "+
 		"Value of FLYTE_TTL_IN_SECONDS: this-string-cannot-be-converted-to-int!!!", logMessages[0].Message)
 
 }

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"net/http"
 	"github.com/HotelsDotCom/flyte/server"
 	"github.com/HotelsDotCom/go-logger"
+	"net/http"
 )
 
 func main() {

--- a/pack/handler.go
+++ b/pack/handler.go
@@ -47,6 +47,8 @@ func PostPack(w http.ResponseWriter, r *http.Request) {
 	logger.Infof("Pack registered: PackId=%s", pack.Id)
 	w.Header().Set("Location", httputil.UriBuilder(r).Path(flytepath.PacksPath, pack.Id).Build())
 	w.WriteHeader(http.StatusCreated)
+
+	httputil.WriteResponse(w, r, toPackResponse(r, *pack))
 }
 
 func GetPacks(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds the functionality so that when a pack is registered with the API, the pack, with populated links, is returned in the response.

This enables the client to only make 1 call to the API server instead of 2 when registering a pack.