### PR TITLE
Configure Travis to push latest docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,12 @@ script:
 
 before_deploy:
   - docker login -u $DOCKER_USER -p $DOCKER_PASS
+  - docker tag $IMAGE:$MAJOR_VERSION.$TRAVIS_BUILD_NUMBER $IMAGE:latest
 
 deploy:
   provider: script
   script:
-    - docker push $IMAGE:$MAJOR_VERSION.$TRAVIS_BUILD_NUMBER
+    - docker push $IMAGE:$MAJOR_VERSION.$TRAVIS_BUILD_NUMBER && docker push $IMAGE:latest
   on:
     branch: master
 


### PR DESCRIPTION
Having a tag 'latest' pushed to DockerHub allows users to `docker pull hotelsdotcom/flyte` without the need to specify a version. Also, a user may want to always use the latest image version. 