### PR TITLE
Ensure go resolves from /etc/hosts in preference to dns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=0 go build
 # Run image
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
 ENV APP=flyte
 WORKDIR /app
 COPY --from=build-env /go/src/github.com/HotelsDotCom/$APP/$APP $APP


### PR DESCRIPTION
This is to help avoid flaky startup behaviour when running `docker run` examples (e.g. Flyte intermittently unable to connect to  Mongo when running in a linked container.

@fooksca @jollinshead - as discussed