### PR TITLE
Fixes #19, improved 'make run'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 flyte
+flyte.out
 
 # initellij files
 .idea

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ build:
 	go build
 
 run: build run-mongo
-	./flyte &
+	nohup ./flyte &> flyte.out &
+	echo "OK: flyte successfully started, output is in flyte.out file"
 
 stop: stop-mongo
 	killall flyte

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ Build & run:
 ```
 make run
 ```
- 
+
+Command starts mongo docker container and flyte go executable in the background. Output is written to `flyte.out` file.
+
 or manually...
- 
+
 ```
 dep ensure
 go test ./... -tags="integration acceptance" //remove tags if only want to run unit tests


### PR DESCRIPTION
`make run` runs in the backround, detached shell and output is stored in a file