### PR TITLE
Add mongo dial retry

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -73,8 +73,8 @@ func dial(url string) *mgo.Session {
 		time.Sleep(mongoDialRetryWait)
 		return dial(url)
 	}
+
 	s.SetSyncTimeout(1 * time.Minute)
 	s.SetSocketTimeout(1 * time.Minute)
-
 	return s
 }

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,0 +1,76 @@
+package mongo
+
+import (
+	"fmt"
+	"github.com/HotelsDotCom/go-logger/loggertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func resetMongoTimeouts(dial, retry time.Duration){
+	mongoDialTimeout      = dial
+	mongoDialRetryWait    = retry
+}
+
+func Test_InitSession_ShouldFailFastWhenMongoURLIsMalformed(t *testing.T) {
+
+	defer loggertest.Reset()
+	defer resetMongoTimeouts(mongoDialTimeout, mongoDialRetryWait)
+	loggertest.Init(loggertest.LogLevelFatal)
+	mongoDialTimeout = 100 * time.Millisecond
+	mongoDialRetryWait = 100 * time.Millisecond
+	c := make(chan struct{})
+	url := "malformed-mongo-url?@"
+
+	// when
+	go func() {
+		defer func(){c <- struct{}{}}()
+		assert.Panics(t, func(){InitSession(url, 365 * 24 * 60 * 60)})
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		assert.FailNow(t, "Test has timeout while connecting to mongo")
+	case <-c:
+	}
+
+	// then
+	logMessages := loggertest.GetLogMessages()
+	require.NotEmpty(t, logMessages)
+
+	expectedError := fmt.Sprintf("Invalid mongo url=%s: connection option must be key=value: @", url)
+	assert.Equal(t, expectedError, logMessages[0].Message)
+}
+
+
+func Test_InitSession_ShouldKeepTryingToConnectToMongo(t *testing.T) {
+	defer loggertest.Reset()
+	defer resetMongoTimeouts(mongoDialTimeout, mongoDialRetryWait)
+	loggertest.Init(loggertest.LogLevelError)
+	mongoDialTimeout = 100 * time.Millisecond
+	mongoDialRetryWait = 100 * time.Millisecond
+	c := make(chan struct{})
+	url := "mongodb://localhost:27017/flyte"
+
+	// when
+	go func() {
+		defer func(){c <- struct{}{}}()
+		assert.NotPanics(t, func(){InitSession(url, 365 * 24 * 60 * 60)})
+	}()
+
+	select {
+	case <-time.After(2 * time.Second):
+	case <-c:
+	}
+
+	// then
+	logMessages := loggertest.GetLogMessages()
+	require.NotEmpty(t, logMessages)
+	require.True(t, len(logMessages) > 2)
+
+	expectedError := fmt.Sprintf("Unable to connect to mongo on url=%s will retry in %s: no reachable servers", url, mongoDialRetryWait)
+	assert.Equal(t, expectedError, logMessages[0].Message)
+	assert.Equal(t, expectedError, logMessages[1].Message)
+}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -61,14 +61,14 @@ func Test_InitSession_ShouldKeepTryingToConnectToMongo(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(2 * time.Second):
+	case <-time.After(3 * time.Second):
 	case <-c:
 	}
 
 	// then
 	logMessages := loggertest.GetLogMessages()
 	require.NotEmpty(t, logMessages)
-	require.True(t, len(logMessages) > 2)
+	require.True(t, len(logMessages) > 1)
 
 	expectedError := fmt.Sprintf("Unable to connect to mongo on url=%s will retry in %s: no reachable servers", url, mongoDialRetryWait)
 	assert.Equal(t, expectedError, logMessages[0].Message)

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -52,7 +52,7 @@ func Test_InitSession_ShouldKeepTryingToConnectToMongo(t *testing.T) {
 	mongoDialTimeout = 100 * time.Millisecond
 	mongoDialRetryWait = 100 * time.Millisecond
 	c := make(chan struct{})
-	url := "mongodb://localhost:27017/flyte"
+	url := "localhost"
 
 	// when
 	go func() {
@@ -61,13 +61,14 @@ func Test_InitSession_ShouldKeepTryingToConnectToMongo(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 	case <-c:
 	}
 
 	// then
 	logMessages := loggertest.GetLogMessages()
 	require.NotEmpty(t, logMessages)
+	fmt.Println(len(logMessages))
 	require.True(t, len(logMessages) > 1)
 
 	expectedError := fmt.Sprintf("Unable to connect to mongo on url=%s will retry in %s: no reachable servers", url, mongoDialRetryWait)

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -61,7 +61,7 @@ func Test_InitSession_ShouldKeepTryingToConnectToMongo(t *testing.T) {
 	}()
 
 	select {
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 	case <-c:
 	}
 


### PR DESCRIPTION
Add fail fast when mongo url is malformed.
Add mongo dial retry until it is available.