### PR TITLE
Add JSON unmarshal function for use in templates

### DIFF
--- a/template/pongo.go
+++ b/template/pongo.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 	"github.com/gorhill/cronexpr"
+	"encoding/json"
 )
 
 func init() {
@@ -43,6 +44,7 @@ func init() {
 	AddStaticContextEntry("base64Decode", base64Decode)
 	AddStaticContextEntry("datastore", datastoreFn)
 	AddStaticContextEntry("template", template)
+	AddStaticContextEntry("unmarshalJson", unmarshalJson)
 }
 
 // Executes a template with given context and returns the rendered template as a string
@@ -151,4 +153,12 @@ func matchesCron(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.
 	}
 
 	return pongo2.AsValue(ce.Matches(t)), nil
+}
+
+func unmarshalJson(in string) map[string]interface{} {
+	out := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(in), &out); err != nil {
+		panic(err)
+	}
+	return out
 }

--- a/template/pongo_test.go
+++ b/template/pongo_test.go
@@ -39,6 +39,12 @@ func TestRandomAlphaShouldGenerateRandomAlphaStringOfRequestedSize(t *testing.T)
 	assert.Regexp(t, "^[A-Za-z]{10}$", val.(string))
 }
 
+func TestUnmarshallJson(t *testing.T) {
+	val, err := Resolve(`it is {{ unmarshalJson(j).foo }}`, Context{"j": `{"foo":"bar"}`})
+	require.NoError(t, err)
+	assert.Equal(t, "it is bar", val)
+}
+
 func TestRandomAlphaShouldReturnErrorIfLengthIsNegative(t *testing.T) {
 	_, err := Resolve("{{ randomAlpha(-5) }}", nil)
 

--- a/template/pongo_test.go
+++ b/template/pongo_test.go
@@ -39,16 +39,21 @@ func TestRandomAlphaShouldGenerateRandomAlphaStringOfRequestedSize(t *testing.T)
 	assert.Regexp(t, "^[A-Za-z]{10}$", val.(string))
 }
 
-func TestUnmarshallJson(t *testing.T) {
+func TestRandomAlphaShouldReturnErrorIfLengthIsNegative(t *testing.T) {
+	_, err := Resolve("{{ randomAlpha(-5) }}", nil)
+
+	assert.EqualError(t, err, "error while evaluating expression: '{{ randomAlpha(-5) }}': word length must be non-negative")
+}
+
+func TestUnmarshallJsonValid(t *testing.T) {
 	val, err := Resolve(`it is {{ unmarshalJson(j).foo }}`, Context{"j": `{"foo":"bar"}`})
 	require.NoError(t, err)
 	assert.Equal(t, "it is bar", val)
 }
 
-func TestRandomAlphaShouldReturnErrorIfLengthIsNegative(t *testing.T) {
-	_, err := Resolve("{{ randomAlpha(-5) }}", nil)
-
-	assert.EqualError(t, err, "error while evaluating expression: '{{ randomAlpha(-5) }}': word length must be non-negative")
+func TestUnmarshallJsonInvalid(t *testing.T) {
+	_, err := Resolve(`this should error: {{ unmarshalJson(j).foo }}`, Context{"j": `{"foo":}`})
+	require.Error(t, err)
 }
 
 func TestTemplateFunctionShouldResolveTemplateWithProvidedContext(t *testing.T) {


### PR DESCRIPTION
Adds a simple `unmarshalJson` function for use in templates so parameters that are a JSON string can be processed (for example: stdout from Shell Pack event)