### PR TITLE
Auto 1091/hateoas fields review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-build:
-	dep ensure
-	go test ./... -tags="integration acceptance"
+build: test
 	go build
 
 run: build run-mongo
@@ -27,5 +25,4 @@ docker-stop: stop-mongo
 
 test:
 	dep ensure
-	go test ./...
 	go test ./... -tags="integration acceptance"

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,8 @@ docker-run: docker-build run-mongo
 
 docker-stop: stop-mongo
 	docker rm -f flyte
+
+test:
+	dep ensure
+	go test ./...
+	go test ./... -tags="integration acceptance"

--- a/pack/handler.go
+++ b/pack/handler.go
@@ -42,7 +42,7 @@ func PostPack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := checkLinks(pack); err != nil {
+	if err := validateLinks(pack); err != nil {
 		logger.Errorf("invalid links found: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -116,7 +116,7 @@ func DeletePack(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func checkLinks(p *Pack) error {
+func validateLinks(p *Pack) error {
 	for _, link := range p.Links {
 		if hateoasRegex.MatchString(link.Rel) {
 			return fmt.Errorf("you can't use %s as it collides with flyte relative links", link.Rel)

--- a/pack/handler.go
+++ b/pack/handler.go
@@ -18,11 +18,11 @@ package pack
 
 import (
 	"encoding/json"
-	"github.com/husobee/vestigo"
-	"net/http"
 	"github.com/HotelsDotCom/flyte/flytepath"
 	"github.com/HotelsDotCom/flyte/httputil"
 	"github.com/HotelsDotCom/go-logger"
+	"github.com/husobee/vestigo"
+	"net/http"
 	"time"
 )
 
@@ -32,11 +32,13 @@ func PostPack(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	pack := &Pack{}
-	if err := json.NewDecoder(r.Body).Decode(pack); err != nil {
+
+	if err := decode(r, pack); err != nil {
 		logger.Errorf("Cannot convert request to pack: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+
 	pack.generateId()
 	pack.LastSeen = time.Now()
 
@@ -103,4 +105,11 @@ func DeletePack(w http.ResponseWriter, r *http.Request) {
 
 	logger.Infof("Pack PackId=%s deleted", packId)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func decode(r *http.Request, v ok) error {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		return err
+	}
+	return v.OK()
 }

--- a/pack/handler.go
+++ b/pack/handler.go
@@ -24,10 +24,12 @@ import (
 	"github.com/HotelsDotCom/go-logger"
 	"github.com/husobee/vestigo"
 	"net/http"
+	"regexp"
 	"time"
 )
 
 var packRepo Repository = packMgoRepo{}
+var hateoasRegex, _ = regexp.Compile("up|self|/actionResult$|/takeAction$|/event$")
 
 func PostPack(w http.ResponseWriter, r *http.Request) {
 

--- a/pack/handler_test.go
+++ b/pack/handler_test.go
@@ -19,14 +19,14 @@ package pack
 import (
 	"encoding/json"
 	"errors"
+	"github.com/HotelsDotCom/flyte/flytepath"
+	"github.com/HotelsDotCom/flyte/httputil"
+	"github.com/HotelsDotCom/go-logger/loggertest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"github.com/HotelsDotCom/flyte/flytepath"
-	"github.com/HotelsDotCom/flyte/httputil"
-	"github.com/HotelsDotCom/go-logger/loggertest"
 	"strings"
 	"testing"
 	"time"
@@ -60,7 +60,7 @@ func TestPostPack_ShouldCreatePackForValidRequest(t *testing.T) {
 	var got Pack
 	err = json.Unmarshal(body, &got)
 	require.NoError(t, err)
-	assert.WithinDuration(t, time.Now(), got.LastSeen, 5 * time.Second)
+	assert.WithinDuration(t, time.Now(), got.LastSeen, 5*time.Second)
 
 	lsB, err := json.Marshal(got.LastSeen)
 	require.NoError(t, err)
@@ -69,6 +69,71 @@ func TestPostPack_ShouldCreatePackForValidRequest(t *testing.T) {
 	assert.JSONEq(t, packResp, string(body))
 }
 
+func TestPostPack_ShouldFailWhenHateoasLinksAreGoingToBeOverride(t *testing.T) {
+	defer resetPackRepo()
+	packRepo = mockPackRepo{
+		add: func(pack Pack) error {
+			return nil
+		},
+	}
+
+	tests := []struct {
+		name string
+		link httputil.Link
+	}{
+		{
+			name: "should BadRequest error when 'self' is used",
+			link: httputil.Link{Href: "http://somewhere.com", Rel: "self"},
+		},
+		{
+			name: "should BadRequest error when 'up' is used",
+			link: httputil.Link{Href: "http://somewhere.com", Rel: "up"},
+		},
+		{
+			name: "should BadRequest error when 'Rel' attribute ends with 'actionResult'",
+			link: httputil.Link{Href: "http://somewhere.com", Rel: "somewhere.com/actionResult"},
+		},
+		{
+			name: "should BadRequest error when 'Rel' attribute ends with 'takeAction'",
+			link: httputil.Link{Href: "http://somewhere.com", Rel: "somewhere.com/takeAction"},
+		},
+		{
+			name: "should BadRequest error when 'Rel' attribute ends with '/event'",
+			link: httputil.Link{Href: "http://somewhere.com", Rel: "somewhere.com/something/event"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pack := Pack{
+				Name: "Slack",
+				Commands: []Command{
+					{Name: "SendMessage", Events: []string{"MessageSent", "SendMessageFailed"}},
+				},
+				Events: []Event{
+					{Name: "MessageSent"},
+					{Name: "SendMessageFailed"},
+				},
+				Links: []httputil.Link{
+					{Href: "http://example.com/README.md"},
+				},
+			}
+
+			pack.Links = append(pack.Links, test.link)
+
+			bytes, err := json.Marshal(&pack)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/packs", strings.NewReader(string(bytes)))
+			httputil.SetProtocolAndHostIn(req)
+			flytepath.EnsureUriDocMapIsInitialised(req)
+			w := httptest.NewRecorder()
+			PostPack(w, req)
+
+			resp := w.Result()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
+	}
+}
 
 func TestPostPack_ShouldReturn400ForInvalidRequest(t *testing.T) {
 
@@ -120,7 +185,7 @@ func TestGetPacks_ShouldReturnListOfPacksWithLinks_WhenPacksExist(t *testing.T) 
 	packRepo = mockPackRepo{
 		findAll: func() ([]Pack, error) {
 			slack := Pack{Id: "Slack", Name: "Slack", Labels: map[string]string{"env": "dev"}, LastSeen: tLive}
-			hipChat := Pack{Id: "HipChat", Name: "HipChat", LastSeen:tWarning}
+			hipChat := Pack{Id: "HipChat", Name: "HipChat", LastSeen: tWarning}
 			return []Pack{slack, hipChat}, nil
 		},
 	}

--- a/pack/handler_test.go
+++ b/pack/handler_test.go
@@ -69,7 +69,7 @@ func TestPostPack_ShouldCreatePackForValidRequest(t *testing.T) {
 	assert.JSONEq(t, packResp, string(body))
 }
 
-func TestPostPack_ShouldFailWhenHateoasLinksAreGoingToBeOverride(t *testing.T) {
+func TestPostPack_should_fail_with_bad_request(t *testing.T) {
 	defer resetPackRepo()
 	packRepo = mockPackRepo{
 		add: func(pack Pack) error {
@@ -82,23 +82,23 @@ func TestPostPack_ShouldFailWhenHateoasLinksAreGoingToBeOverride(t *testing.T) {
 		link httputil.Link
 	}{
 		{
-			name: "should BadRequest error when 'self' is used",
+			name: "'self' is used as a relative name",
 			link: httputil.Link{Href: "http://somewhere.com", Rel: "self"},
 		},
 		{
-			name: "should BadRequest error when 'up' is used",
+			name: "'up' is used as a relative name",
 			link: httputil.Link{Href: "http://somewhere.com", Rel: "up"},
 		},
 		{
-			name: "should BadRequest error when 'Rel' attribute ends with 'actionResult'",
+			name: "'Rel' attribute ends with 'actionResult'",
 			link: httputil.Link{Href: "http://somewhere.com", Rel: "somewhere.com/actionResult"},
 		},
 		{
-			name: "should BadRequest error when 'Rel' attribute ends with 'takeAction'",
+			name: "'Rel' attribute ends with 'takeAction'",
 			link: httputil.Link{Href: "http://somewhere.com", Rel: "somewhere.com/takeAction"},
 		},
 		{
-			name: "should BadRequest error when 'Rel' attribute ends with '/event'",
+			name: "'Rel' attribute ends with '/event'",
 			link: httputil.Link{Href: "http://somewhere.com", Rel: "somewhere.com/something/event"},
 		},
 	}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -48,25 +48,12 @@ type Event struct {
 	Links []httputil.Link `json:"links,omitempty"`
 }
 
-type ok interface {
-	OK() error
-}
-
 func (p *Pack) generateId() {
 	id := p.Name
 	for _, k := range collections.SortedKeys(p.Labels) {
 		id += fmt.Sprintf(".%s.%s", k, p.Labels[k])
 	}
 	p.Id = id
-}
-
-func (p *Pack) OK() error {
-	for _, link := range p.Links {
-		if hateoasRegex.MatchString(link.Rel) {
-			return fmt.Errorf("you can't use %s as it collides with flyte relative links", link.Rel)
-		}
-	}
-	return nil
 }
 
 type Repository interface {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -31,7 +31,6 @@ type Pack struct {
 	Commands []Command         `json:"commands,omitempty"`
 	Events   []Event           `json:"events,omitempty"`
 	LastSeen time.Time         `json:"lastSeen,omitempty" bson:"lastSeen,omitempty"`
-	Status   string            `json:"status,omitempty"`
 	Links    []httputil.Link   `json:"links,omitempty"`
 }
 
@@ -53,17 +52,6 @@ func (p *Pack) generateId() {
 		id += fmt.Sprintf(".%s.%s", k, p.Labels[k])
 	}
 	p.Id = id
-}
-
-func (p *Pack) setStatus() {
-	d := time.Since(p.LastSeen)
-	if d < 10 * time.Minute {
-		p.Status = "live"
-	} else if d < 24 * time.Hour {
-		p.Status = "warning"
-	} else {
-		p.Status = "critical"
-	}
 }
 
 type Repository interface {

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 	"github.com/HotelsDotCom/flyte/collections"
 	"github.com/HotelsDotCom/flyte/httputil"
-	"regexp"
 	"time"
 )
-
-var hateoasRegex, _ = regexp.Compile("up|self|/actionResult$|/takeAction$|/event$")
 
 type Pack struct {
 	Id       string            `json:"id" bson:"_id"`

--- a/pack/pack_test.go
+++ b/pack/pack_test.go
@@ -23,7 +23,7 @@ func TestPack_SetStatus(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.want + "_duration:" + now.Sub(tt.lastSeen).String(), func(t *testing.T) {
-			p := Pack{LastSeen: tt.lastSeen}
+			p := packResponse{Pack: Pack{LastSeen: tt.lastSeen}}
 			p.setStatus()
 			assert.Equal(t, tt.want, p.Status)
 		})


### PR DESCRIPTION
- Status field moved to response entity. At the moment, someone can set the initial status in the DB during pack registration.
- A malicious user can add a relative link to our HATEOAS component, and flyte-client will pick the first link that matches that name. We should shield this endpoint to avoid users to inject some HATEOAS reserved links.

NOTE: The ideal solution would be having a unique relative name and fix all flyte-clients to pick links if they match, and not only if they ends with an specific name.