### PR TITLE
Adding the ability to extract a capture group

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 h1:f0n1xnMSmBLzVfsMMvriDyA75NB/oBgILX2GcHXIQzY=
 github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75/go.mod h1:g2644b03hfBX9Ov0ZBDgXXens4rxSxmqFBbhvKv2yVA=
+github.com/husobee/vestigo v1.1.0 h1:HugdGUfco/gq7lfsQf3zUrPxAHpl7Be6xv79E57h4Es=
 github.com/husobee/vestigo v1.1.0/go.mod h1:JigD7C8lzUfpo1uzqYgefpyZLswrtJbAQxMw7ds7YCE=
 github.com/jasonlvhit/gocron v0.0.0-20190920201010-985d45da66c5 h1:m1t5VsnIRS9HY+X/NReDtPvLriGcMx3Foc8a97Ogyyk=
 github.com/jasonlvhit/gocron v0.0.0-20190920201010-985d45da66c5/go.mod h1:rwi/esz/h+4oWLhbWWK7f6dtmgLzxeZhnwGr7MCsTNk=
@@ -49,13 +50,16 @@ github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVE
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073 h1:WQM1NildKThwdP7qWrNAFGzp4ijNLw8RlgENkaI4MJs=
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
@@ -108,4 +112,5 @@ gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/template/pongo.go
+++ b/template/pongo.go
@@ -36,6 +36,7 @@ func init() {
 	pongo2.RegisterFilter("kvp", keyValuePair)
 	pongo2.RegisterFilter("index", index)
 	pongo2.RegisterFilter("matchesCron", matchesCron)
+	pongo2.RegisterFilter("extractMatch", extractMatch)
 
 	rand.Seed(time.Now().UTC().UnixNano())
 	AddStaticContextEntry("randomInt", randomInt)
@@ -72,6 +73,16 @@ func getValueByKey(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo
 func match(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 	match, _ := regexp.MatchString(param.String(), in.String())
 	return pongo2.AsValue(match), nil
+}
+
+func extractMatch(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	matcher, _ := regexp.Compile(param.String())
+	match := matcher.FindStringSubmatch(in.String())
+	if len(match) > 1 {
+		return pongo2.AsValue(match[1]), nil
+	} else {
+		return pongo2.AsValue(in.String()), nil
+	}
 }
 
 func keyValuePair(in *pongo2.Value, _ *pongo2.Value) (*pongo2.Value, *pongo2.Error) {

--- a/template/pongo_test.go
+++ b/template/pongo_test.go
@@ -115,3 +115,34 @@ func TestMatchesCronExpressionReturnsErrorWhenAnInvalidCronExpressionIsGiven(t *
 	assert.EqualError(t, err, "error while evaluating expression: '{{ \"2018-02-14T23:18:09."+
 		"0481031Z\" | matchesCron: \"not a cron expression\" }}': [Error | Line 1 Col 57 near 'matchesCron'] missing field(s)")
 }
+
+func TestMatchReturnsTrueForValidMatch(t *testing.T) {
+	matched, err := Resolve(`{{ "foobar" | match:'^[fo]+bar.*$' }}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "True", matched)
+}
+
+func TestMatchReturnsFalseForNoMatch(t *testing.T) {
+	matched, err := Resolve(`{{ "foobar" | match:'^Foobar$' }}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "False", matched)
+}
+
+func TestExtractMatchReturnsFirstGroupForMatch(t *testing.T) {
+	matched, err := Resolve(`{{ "foo bar baz bay" | extractMatch:'\\w+ \\w+ (\\w+) (\\w+)' }}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "baz", matched)
+}
+
+func TestExtractMatchReturnsFullInputForNoMatch(t *testing.T) {
+	failedMatch, err := Resolve(`{{ "foo bar baz" | extractMatch:'\\w+ \\w+ (\\d+)' }}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "foo bar baz", failedMatch)
+}
+
+func TestExtractMatchReturnsFullInputForNoCaptureGroup(t *testing.T) {
+	failedMatch, err := Resolve(`{{ "foo bar baz" | extractMatch:'\\w+ \\w+ \\w+' }}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "foo bar baz", failedMatch)
+}
+

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -123,6 +123,22 @@ func TestResolveShouldResolveValidPongoTemplates(t *testing.T) {
 			`pongo`,
 		},
 		{
+			`{{ "pongo version new"|extractMatch:'\\w+ \\w+ (\\w+)' }}`,
+			`new`,
+		},
+		{
+			`{{ "the good, the bad, and the-ugly"|extractMatch:'.* ([-a-zA-Z0-9_]+)' }}`,
+			`the-ugly`,
+		},
+		{
+			`{{ "How do you defeat a Quylthulg?"|extractMatch:'.* ([-a-zA-Z0-9_]+)\\W*' }}`,
+			`Quylthulg`,
+		},
+		{
+			`{{ "What is your name?"|extractMatch:'.* (\\w+)$' }}`,
+			`What is your name?`,
+		},
+		{
 			`Event Name {{Event.Name}}, Pack name {{Event.Pack.Name}}, Pack label {{Event.Pack.Labels.network}}`,
 			`Event Name InventoryUpdateSuccess, Pack name Flyte, Pack label lab`,
 		},


### PR DESCRIPTION
This makes it easier to do things like ignore final question marks for triggers like `Flyte, what is user-service?`. Now you can just capture `user-service` in a capture group rather than trying to split and exclude the `?`.